### PR TITLE
add CMK peer-review track template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ in NBIS support work at the following places:
  * [Roy's R Markdown templates](https://github.com/royfrancis/minty)
  * [Erik's NBIS Quarto template](https://github.com/NBISweden/nbis-templates-quarto)
  * [Rasmus' project template](https://github.com/NBISweden/project_template)
+ * [Cormac's peer review track project template](https://github.com/NBISweden/CMK-NBIS-PRT-project-template)
  * [Cookiecutter Data Science](http://drivendata.github.io/cookiecutter-data-science/)
 
 ## Setup


### PR DESCRIPTION
Made a template for peer review track projects, which includes a confluence publishing directory and script (grabs all latest meeting schedule, minutes, & progress logbook and pushes to the confluence page with one command).

Has quarto template logbook and meeting minutes (book project) set up for use with quarto render if HTML output is preferred.